### PR TITLE
Option to start the REPL from the buffer directory

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -330,6 +330,13 @@ function! s:codi_do_update()
   " Build the command
   let cmd = s:to_list(i['bin'])
 
+  " the purpose of this is to make the REPL start from buffer directory
+  if g:codi#use_buffer_dir
+    let buf_dir = expand("%:p:h")
+    let cwd = getcwd()
+    exe 'cd '.fnameescape(buf_dir)
+  endif
+
   " Async or sync
   if s:get_opt('async')
     " Spawn the job
@@ -369,6 +376,10 @@ function! s:codi_do_update()
   else
     " Convert command to string
     call s:codi_handle_done(bufnr, system(s:shellescape_list(cmd), input))
+  endif
+  " change back to original cwd to avoid side effects
+  if g:codi#use_buffer_dir
+    exe 'cd '.fnameescape(cwd)
   endif
 endfunction
 

--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -330,7 +330,7 @@ function! s:codi_do_update()
   " Build the command
   let cmd = s:to_list(i['bin'])
 
-  " the purpose of this is to make the REPL start from buffer directory
+  " The purpose of this is to make the REPL start from the buffer directory
   if g:codi#use_buffer_dir
     let buf_dir = expand("%:p:h")
     let cwd = getcwd()
@@ -377,7 +377,8 @@ function! s:codi_do_update()
     " Convert command to string
     call s:codi_handle_done(bufnr, system(s:shellescape_list(cmd), input))
   endif
-  " change back to original cwd to avoid side effects
+
+  " Change back to original cwd to avoid side effects
   if g:codi#use_buffer_dir
     exe 'cd '.fnameescape(cwd)
   endif

--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -331,7 +331,8 @@ function! s:codi_do_update()
   let cmd = s:to_list(i['bin'])
 
   " The purpose of this is to make the REPL start from the buffer directory
-  if g:codi#use_buffer_dir
+  let opt_use_buffer_dir = s:get_opt('use_buffer_dir')
+  if opt_use_buffer_dir
     let buf_dir = expand("%:p:h")
     if !s:nvim
       let cwd = getcwd()
@@ -348,7 +349,7 @@ function! s:codi_do_update()
             \ 'on_stdout': function('s:codi_nvim_callback'),
             \ 'on_stderr': function('s:codi_nvim_callback'),
             \}
-      if g:codi#use_buffer_dir
+      if opt_use_buffer_dir
         let job_options.cwd = buf_dir
       endif
       let job = jobstart(cmd, job_options)
@@ -385,7 +386,7 @@ function! s:codi_do_update()
   endif
 
   " Change back to original cwd to avoid side effects
-  if g:codi#use_buffer_dir && !s:nvim
+  if opt_use_buffer_dir && !s:nvim
     exe 'cd '.fnameescape(cwd)
   endif
 endfunction

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -35,6 +35,7 @@ CONFIGURATION.............................................|codi-configuration|
     g:codi#autoclose........................................|g:codi#autoclose|
     g:codi#raw....................................................|g:codi#raw|
     g:codi#sync..................................................|g:codi#sync|
+	g:codi#use_buffer_dir..............................g:codi#use_buffer_dir
 AUTOCOMMANDS...............................................|codi-autocommands|
     CodiEnterPre................................................|CodiEnterPre|
     CodiEnterPost..............................................|CodiEnterPost|
@@ -263,6 +264,15 @@ g:codi#sync
              No reason to touch this unless you want to compare async to sync.
 
              Default value is 0.
+
+                                                       *g:codi#use_buffer_dir*
+g:codi#use_buffer_dir
+             Whether or not switch to switch to the directory of the buffer
+			 being edited before starting the REPL. This allows the REPL to
+			 start from that directory which can make it easier to use
+			 relative paths from your code.
+
+             Default value is 1.
 
 ==============================================================================
 AUTOCOMMANDS                                               *codi-autocommands*

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -267,10 +267,9 @@ g:codi#sync
 
                                                        *g:codi#use_buffer_dir*
 g:codi#use_buffer_dir
-             Whether or not switch to switch to the directory of the buffer
-             being edited before starting the REPL. This allows the REPL to
-             start from that directory which can make it easier to use
-             relative paths from your code.
+             Start the REPL with the working directory of the buffer being
+             edited instead of Vim's current working directory. This can make
+             it easier for your code to use paths relative to the script path.
 
              Default value is 1.
 

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -35,7 +35,7 @@ CONFIGURATION.............................................|codi-configuration|
     g:codi#autoclose........................................|g:codi#autoclose|
     g:codi#raw....................................................|g:codi#raw|
     g:codi#sync..................................................|g:codi#sync|
-	g:codi#use_buffer_dir..............................g:codi#use_buffer_dir
+	g:codi#use_buffer_dir..............................|g:codi#use_buffer_dir|
 AUTOCOMMANDS...............................................|codi-autocommands|
     CodiEnterPre................................................|CodiEnterPre|
     CodiEnterPost..............................................|CodiEnterPost|

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -35,7 +35,7 @@ CONFIGURATION.............................................|codi-configuration|
     g:codi#autoclose........................................|g:codi#autoclose|
     g:codi#raw....................................................|g:codi#raw|
     g:codi#sync..................................................|g:codi#sync|
-	g:codi#use_buffer_dir..............................|g:codi#use_buffer_dir|
+    g:codi#use_buffer_dir..............................|g:codi#use_buffer_dir|
 AUTOCOMMANDS...............................................|codi-autocommands|
     CodiEnterPre................................................|CodiEnterPre|
     CodiEnterPost..............................................|CodiEnterPost|
@@ -268,9 +268,9 @@ g:codi#sync
                                                        *g:codi#use_buffer_dir*
 g:codi#use_buffer_dir
              Whether or not switch to switch to the directory of the buffer
-			 being edited before starting the REPL. This allows the REPL to
-			 start from that directory which can make it easier to use
-			 relative paths from your code.
+             being edited before starting the REPL. This allows the REPL to
+             start from that directory which can make it easier to use
+             relative paths from your code.
 
              Default value is 1.
 
@@ -428,7 +428,7 @@ preprocess (OPTIONAL)
              the corresponding lines.
 
              The function should take a single string argument that is a line
-             of output, and return a single string that is the adjusted line 
+             of output, and return a single string that is the adjusted line
              of output.
 
              When creating your own preprocess, it is useful to enable

--- a/plugin/codi.vim
+++ b/plugin/codi.vim
@@ -63,5 +63,10 @@ if !exists('g:codi#sync')
   let g:codi#sync = 0
 endif
 
+" Start REPL from the directory of the buffer being edited?
+if !exists('g:codi#use_buffer_dir')
+  let g:codi#use_buffer_dir = 1
+endif
+
 command! -nargs=? -bang -bar -complete=filetype Codi call codi#run(<bang>0, <f-args>)
 command! -bar CodiUpdate call codi#update()


### PR DESCRIPTION
Defaults to on. The way it works is by changing Vim's current
working directory to match the directory of the file buffer
before starting the REPL. It changes the cwd back to what it
originally was to minimize side effects. This can make it easier
for the users code to use path relative to that script. I tried
changing the cwd option passed to jobstart() for Neovim, but
that did not seem to have any effect. Let me know if you have
an idea for a cleaner, more side effect free way of achieving
this. I don't mind if you want this to default to off instead.