### PR TITLE
Clojure/Clojurescript support via Planck (~1 sec lag) (fixes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or Vim with `+job` and `+channel`, asynchronously). It's extensible to nearly
 any language that provides a REPL (interactive interpreter)!
 
 Languages with built-in support:
-Python, JavaScript, CoffeeScript, Haskell, Ruby, OCaml, R
+Python, JavaScript, CoffeeScript, Haskell, Ruby, OCaml, R, Clojure/ClojureScript
 
 [Pull requests](https://github.com/metakirby5/codi.vim/pulls)
 for new language support welcome!
@@ -62,6 +62,7 @@ Default interpreter dependencies:
   - Ruby:         `irb`
   - OCaml:        `ocaml`
   - R:            `R`
+  - Clojure:      `planck`
 
 ## Usage
 

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -64,8 +64,8 @@ let s:codi_default_interpreters = {
           \ 'preprocess': function('s:pp_r'),
           \ },
       \ 'clojure': {
-          \ 'bin': ['grench', 'repl'],
-          \ 'prompt': '^\(user=>\|#_=>\) ',
+          \ 'bin': ['planck', '--verbose', '--dumb-terminal'],
+          \ 'prompt': '^.\{-}=> ',
           \ }
       \ }
 function! codi#load#interpreters()

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -66,7 +66,7 @@ let s:codi_default_interpreters = {
       \ 'clojure': {
           \ 'bin': ['planck', '--verbose', '--dumb-terminal'],
           \ 'prompt': '^.\{-}=> ',
-          \ }
+          \ },
       \ }
 function! codi#load#interpreters()
   return s:deep_extend(s:codi_default_interpreters, g:codi#interpreters)

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -62,6 +62,10 @@ let s:codi_default_interpreters = {
           \ 'bin': 'R',
           \ 'prompt': '^> ',
           \ 'preprocess': function('s:pp_r'),
+          \ },
+      \ 'clojure': {
+          \ 'bin': ['grench', 'repl'],
+          \ 'prompt': '^\(user=>\|#_=>\) ',
           \ }
       \ }
 function! codi#load#interpreters()

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -323,6 +323,7 @@ Codi currently has default support for the following filetypes:
           | haskell    | ghci   | Language pragmas don't work      |
           | ruby       | irb    |                                  |
           | ocaml      | ocaml  | Must end every statement with ;; |
+          | clojure    | planck |                                  |
           +------------+--------+----------------------------------+
 
 Note that Codi is not meant to be a replacement for actually running your


### PR DESCRIPTION
Using [planck](http://planck-repl.org/). Originally tried several alternatives

- `lein repl` takes much longer
- `grench repl` was instant but requires a `project.clj` file, starting up a headless REPL to (re)connect to (state issues) and can't parse multiline s-expressions.

In the spirit of k.i.s.s, I think this is the way to go, though launching [planck's socket REPL](http://planck-repl.org/socket-repl.html) and (re)connecting to it may make things faster (currently not in their Linux release [yet](https://github.com/mfikes/planck/pull/297), and I don't has OSX to test that out).