### PR TITLE
Feature/js squelch undefined

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -37,7 +37,7 @@ let s:codi_default_interpreters = {
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
           \ },
       \ 'javascript': {
-          \ 'bin': ['node','-e','require("repl").start({ignoreUndefined:true})'],
+          \ 'bin': ['node', '-e', 'require("repl").start({ignoreUndefined: true})'],
           \ 'prompt': '^\(>\|\.\.\.\+\) ',
           \ },
       \ 'coffee': {

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -37,7 +37,7 @@ let s:codi_default_interpreters = {
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
           \ },
       \ 'javascript': {
-          \ 'bin': 'node',
+          \ 'bin': ['node','-e','require("repl").start({ignoreUndefined:true})'],
           \ 'prompt': '^\(>\|\.\.\.\+\) ',
           \ },
       \ 'coffee': {

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -337,7 +337,7 @@ Codi currently has default support for the following filetypes:
           | Filetype   | bin    | Notes                            |
           +------------+--------+----------------------------------+
           | python     | python | Cannot leave empty lines in defs |
-          | javascript | node   | "var" and "let" show undefined   |
+          | javascript | node   | ignoreUndefined by default       |
           | coffee     | coffee | Blank lines show undefined       |
           | haskell    | ghci   | Language pragmas don't work      |
           | ruby       | irb    |                                  |


### PR DESCRIPTION
Ignores `undefined` output from the node repl.

It also shows output from `console.log`.
Since `console.log()` displays output then returns `undefined`, this PR ignores the `undefined` output from node repl, allowing the `console.log` output to be displayed by Codi.

**Before PR**
![ignoreUndefined](https://imgur.com/1TrfyTM.png)

**After PR**
![undefined](https://imgur.com/bo806T6.png)