### PR TITLE
restored normal node global context behavior:

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -37,7 +37,7 @@ let s:codi_default_interpreters = {
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
           \ },
       \ 'javascript': {
-          \ 'bin': ['node', '-e', 'require("repl").start({ignoreUndefined: true})'],
+          \ 'bin': ['node', '-e', 'require("repl").start({ignoreUndefined: true, useGlobal: true})'],
           \ 'prompt': '^\(>\|\.\.\.\+\) ',
           \ },
       \ 'coffee': {


### PR DESCRIPTION
Now that custom node REPL behavior is specified, it is a good idea
to enable the global context. If the standard REPL was being used,
the global context would be used. Also, when not running as a REPL,
node normally uses this context, so this option prevents the REPL
from further deviating from normal node behavior. Some JavaScript
code relies on the global context to work correctly.