### PR TITLE
Ignore python and ruby config files

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -33,7 +33,7 @@ function! s:pp_r(line)
 endfunction
 let s:codi_default_interpreters = {
       \ 'python': {
-          \ 'bin': 'python',
+          \ 'bin': ['env', 'PYTHONSTARTUP=', 'python'],
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
           \ },
       \ 'javascript': {
@@ -49,7 +49,7 @@ let s:codi_default_interpreters = {
           \ 'prompt': '^Prelude[^>|]*[>|] ',
           \ },
       \ 'ruby': {
-          \ 'bin': 'irb',
+          \ 'bin': ['irb', '-f'],
           \ 'prompt': '^irb(\w\+):\d\+:\d\+. ',
           \ 'preprocess': function('s:pp_remove_fat_arrow'),
           \ },


### PR DESCRIPTION
Python's `$PYTHONSTARTUP` and Ruby's `~/.irbrc` files can interfere with the default `g:codi#interpreters` values, like `prompt`.

This change turns those configurations off so that Codi works out of the box.

See [Issue #31](https://github.com/metakirby5/codi.vim/issues/31#issuecomment-251570996) for more info.