### PR TITLE
Added support for PureScript's PSCi interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or Vim with `+job` and `+channel`, asynchronously). It's extensible to nearly
 any language that provides a REPL (interactive interpreter)!
 
 Languages with built-in support:
-Python, JavaScript, CoffeeScript, Haskell, Ruby, OCaml, R,
+Python, JavaScript, CoffeeScript, Haskell, PureScript, Ruby, OCaml, R,
 Clojure/ClojureScript, PHP, Lua, C++
 
 [Pull requests](https://github.com/metakirby5/codi.vim/pulls)
@@ -60,6 +60,7 @@ Default interpreter dependencies:
   - JavaScript:   `node`
   - CoffeeScript: `coffee`
   - Haskell:      `ghci` (be really careful with lazy evaluation!)
+  - PureScript    `pulp psci`
   - Ruby:         `irb`
   - OCaml:        `ocaml`
   - R:            `R`

--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -540,7 +540,7 @@ function! s:codi_handle_done(bufnr, output)
     let output = a:output
   endif
 
-  " Unless raw, parse for propmt
+  " Unless raw, parse for prompt
   " Basic algorithm, for all lines:
   "   If we hit a prompt,
   "     If we have already passed the first prompt, record our taken line.

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -48,6 +48,11 @@ let s:codi_default_interpreters = {
           \ 'bin': 'ghci',
           \ 'prompt': '^Prelude[^>|]*[>|] ',
           \ },
+      \ 'purescript': {
+          \ 'bin': ['pulp', 'psci'],
+          \ 'prompt': '^[^>…]*[>…] ',
+          \ 'quitcmd': ':q',
+          \ },
       \ 'ruby': {
           \ 'bin': ['irb', '-f'],
           \ 'prompt': '^irb(\w\+):\d\+:\d\+. ',

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -31,6 +31,51 @@ function! s:pp_r(line)
   " Just return everything after the braces
   return substitute(a:line, '\s*\[\d\+\]\s*\(.*\)$', '\1', '')
 endfunction
+let s:pp_purs_state = {}
+let g:log = []
+function! s:pp_purs(line)
+  let l = a:line
+  let rgx_prompt = s:codi_default_interpreters.purescript.prompt
+  if exists('g:codi#interpreters.purescript.prompt')
+    " Prompt regex overridden by user
+    let rgx_prompt = g:codi#interpreters.purescript.prompt
+  endif
+  let rgxs_ignore = [
+      \ '\s*See.*',
+      \ '\s*or to contribute.*',
+      \ ]
+  let rgx_trimlast = '\s*See.*'
+  if l =~ rgx_prompt
+    let g:log += ['PROMPT']
+    " If line saved, send through before next prompt
+    if exists('s:pp_purs_state.lastline')
+      let g:log[-1] .= ', RELEASING: ' . s:pp_purs_state.lastline
+      let l = s:pp_purs_state.lastline . "\n" . l
+      unlet s:pp_purs_state.lastline
+    endif
+  else
+    let tmp = ''
+    if exists('s:pp_purs_state.lastline')
+      if l =~ rgx_trimlast
+        " Trim (un-indent) last saved line if special regex matches
+        let s:pp_purs_state.lastline = substitute(s:pp_purs_state.lastline, '^\s*', '', '')
+      endif
+      let tmp = s:pp_purs_state.lastline
+    endif
+    if max(map(copy(rgxs_ignore), 'l =~ v:val'))
+      let g:log += ['IGNORED: ' . l]
+      " Send empty-string if line matched regexes to ignore
+      let l = ''
+    endif
+    if len(l)
+      let g:log += ['SAVED: ' . l . ', REPLACING:' . tmp]
+      let s:pp_purs_state.lastline = l
+      let l = tmp
+    endif
+    unlet tmp
+  endif
+  return l
+endfunction
 
 " Default rephrasers
 function! s:rp_purs(buf)
@@ -61,6 +106,7 @@ let s:codi_default_interpreters = {
           \ 'bin': ['pulp', 'psci'],
           \ 'prompt': '^[^>…]*[>…] ',
           \ 'rephrase': function('s:rp_purs'),
+          \ 'preprocess': function('s:pp_purs'),
           \ 'quitcmd': ':q',
           \ },
       \ 'ruby': {

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -79,10 +79,15 @@ endfunction
 
 " Default rephrasers
 function! s:rp_purs(buf)
-  " Literal Ctrl-d needs to be preceded by literal Ctrl-v
-  " let r = substitute(a:buf, '[^]\zs\ze', '', 'g')
-  " Alternative ":endpaste" to terminate multi-line continuations in psci
-  return substitute(a:buf, ':endpaste\>', '', 'g')
+  let b = a:buf
+  " Alternative to Ctrl-d, ":endpaste" will terminate
+  " multi-line continuations in psci
+  let b = substitute(b, ':endpaste\>', '', 'g')
+  " Remove comments. In PSCi they produce an error
+  " (Multi-line comments not supported here)
+  let b = substitute(b, '\%(^\|[\n\r\x00]\)\s*--[^\n\r\x00]*', '', 'g')
+  " Extra newline to flush any remaining 'lastline' from preprocess
+  return b . "\n"
 endfunction
 
 let s:codi_default_interpreters = {

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -32,7 +32,6 @@ function! s:pp_r(line)
   return substitute(a:line, '\s*\[\d\+\]\s*\(.*\)$', '\1', '')
 endfunction
 let s:pp_purs_state = {}
-let g:log = []
 function! s:pp_purs(line)
   let l = a:line
   let rgx_prompt = s:codi_default_interpreters.purescript.prompt
@@ -46,10 +45,8 @@ function! s:pp_purs(line)
       \ ]
   let rgx_trimlast = '\s*See.*'
   if l =~ rgx_prompt
-    let g:log += ['PROMPT']
     " If line saved, send through before next prompt
     if exists('s:pp_purs_state.lastline')
-      let g:log[-1] .= ', RELEASING: ' . s:pp_purs_state.lastline
       let l = s:pp_purs_state.lastline . "\n" . l
       unlet s:pp_purs_state.lastline
     endif
@@ -63,12 +60,10 @@ function! s:pp_purs(line)
       let tmp = s:pp_purs_state.lastline
     endif
     if max(map(copy(rgxs_ignore), 'l =~ v:val'))
-      let g:log += ['IGNORED: ' . l]
       " Send empty-string if line matched regexes to ignore
       let l = ''
     endif
     if len(l)
-      let g:log += ['SAVED: ' . l . ', REPLACING:' . tmp]
       let s:pp_purs_state.lastline = l
       let l = tmp
     endif

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -40,10 +40,10 @@ function! s:pp_purs(line)
     let rgx_prompt = g:codi#interpreters.purescript.prompt
   endif
   let rgxs_ignore = [
-      \ '\s*See.*',
-      \ '\s*or to contribute.*',
+      \ '\s*See https://github.com/purescript.* for more information,',
+      \ '\s*or to contribute content related to this error.',
       \ ]
-  let rgx_trimlast = '\s*See.*'
+  let rgx_trimlast = '\s*See https://github.com/purescript.* for more information,'
   if l =~ rgx_prompt
     " If line saved, send through before next prompt
     if exists('s:pp_purs_state.lastline')

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -31,6 +31,15 @@ function! s:pp_r(line)
   " Just return everything after the braces
   return substitute(a:line, '\s*\[\d\+\]\s*\(.*\)$', '\1', '')
 endfunction
+
+" Default rephrasers
+function! s:rp_purs(buf)
+  " Literal Ctrl-d needs to be preceded by literal Ctrl-v
+  " let r = substitute(a:buf, '[^]\zs\ze', '', 'g')
+  " Alternative ":endpaste" to terminate multi-line continuations in psci
+  return substitute(a:buf, ':endpaste\>', '', 'g')
+endfunction
+
 let s:codi_default_interpreters = {
       \ 'python': {
           \ 'bin': ['env', 'PYTHONSTARTUP=', 'python'],
@@ -51,6 +60,7 @@ let s:codi_default_interpreters = {
       \ 'purescript': {
           \ 'bin': ['pulp', 'psci'],
           \ 'prompt': '^[^>…]*[>…] ',
+          \ 'rephrase': function('s:rp_purs'),
           \ 'quitcmd': ':q',
           \ },
       \ 'ruby': {

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -359,10 +359,11 @@ Codi currently has default support for the following filetypes:
     +------------+--------+---------------------------------------------+
 
 Note that Codi is not meant to be a replacement for actually running your
-program; it supports nothing more than what the underlying bin supports. This
-is why Haskell language pragmas don't work and OCaml statements must end with
-;;. Also, in most whitespace-sensitive languages, an empty line represents
-the end of a definition, so the below Python class will not work in Codi:
+program; it supports nothing more than what the underlying bin supports.
+This is why Haskell language pragmas don't work, PurseScript only works
+inside a project folder, and OCaml statements must end with ;;. Also, in
+most whitespace-sensitive languages, an empty line represents the end of a
+definition, so the below Python class will not work in Codi:
 >
              class Test(object):
                  def __init__(self):

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -342,20 +342,21 @@ DEFAULT INTERPRETERS                              *codi-interpreters-defaults*
 
 Codi currently has default support for the following filetypes:
 
-          +------------+--------+----------------------------------+
-          | Filetype   | bin    | Notes                            |
-          +------------+--------+----------------------------------+
-          | python     | python | Cannot leave empty lines in defs |
-          | javascript | node   | ignoreUndefined by default       |
-          | coffee     | coffee | Blank lines show undefined       |
-          | haskell    | ghci   | Language pragmas don't work      |
-          | ruby       | irb    |                                  |
-          | ocaml      | ocaml  | Must end every statement with ;; |
-          | clojure    | planck |                                  |
-          | php        | psysh  |                                  |
-          | lua        | lua    | Use a = or return to display val |
-          | cpp        | cling  |                                  |
-          +------------+--------+----------------------------------+
+       +------------+--------+----------------------------------------+
+       | Filetype   | bin    | Notes                                  |
+       +------------+--------+----------------------------------------+
+       | python     | python | Cannot leave empty lines in defs       |
+       | javascript | node   | ignoreUndefined by default             |
+       | coffee     | coffee | Blank lines show undefined             |
+       | haskell    | ghci   | Language pragmas don't work            |
+       | purescript | psci   | End multi-line continuations with  |
+       | ruby       | irb    |                                        |
+       | ocaml      | ocaml  | Must end every statement with ;;       |
+       | clojure    | planck |                                        |
+       | php        | psysh  |                                        |
+       | lua        | lua    | Use a = or return to display val       |
+       | cpp        | cling  |                                        |
+       +------------+--------+----------------------------------------+
 
 Note that Codi is not meant to be a replacement for actually running your
 program; it supports nothing more than what the underlying bin supports. This

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -360,7 +360,7 @@ Codi currently has default support for the following filetypes:
 
 Note that Codi is not meant to be a replacement for actually running your
 program; it supports nothing more than what the underlying bin supports.
-This is why Haskell language pragmas don't work, PurseScript only works
+This is why Haskell language pragmas don't work, PureScript only works
 inside a project folder, and OCaml statements must end with ;;. Also, in
 most whitespace-sensitive languages, an empty line represents the end of a
 definition, so the below Python class will not work in Codi:

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -496,10 +496,11 @@ rephrase (OPTIONAL)
 
              This attribute is actually not recommended, since it is very
              difficult to achieve desired goals without unforeseen
-             side-effects. None of the default interpreters actually use
-             rephrase. However, for example, if you REALLY want
-             "let var x = 5" to show "5" instead of "undefined", this is the
-             way to do it.
+             side-effects. The PureScript interpreter uses rephrase so
+             multi-line continuations can be terminated with ":endpaste"
+             instead of Ctrl-D, which is awkard to type literally.
+             As another example, if you REALLY want "let var x = 5" to
+             show "5" instead of "undefined", this is the way to do it.
 
              The configuration process is similar to preprocess, so just look
              at |codi-interpreters-preprocess| if you're unsure how to start.

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -342,21 +342,21 @@ DEFAULT INTERPRETERS                              *codi-interpreters-defaults*
 
 Codi currently has default support for the following filetypes:
 
-       +------------+--------+----------------------------------------+
-       | Filetype   | bin    | Notes                                  |
-       +------------+--------+----------------------------------------+
-       | python     | python | Cannot leave empty lines in defs       |
-       | javascript | node   | ignoreUndefined by default             |
-       | coffee     | coffee | Blank lines show undefined             |
-       | haskell    | ghci   | Language pragmas don't work            |
-       | purescript | psci   | End multi-line continuations with  |
-       | ruby       | irb    |                                        |
-       | ocaml      | ocaml  | Must end every statement with ;;       |
-       | clojure    | planck |                                        |
-       | php        | psysh  |                                        |
-       | lua        | lua    | Use a = or return to display val       |
-       | cpp        | cling  |                                        |
-       +------------+--------+----------------------------------------+
+    +------------+--------+---------------------------------------------+
+    | Filetype   | bin    | Notes                                       |
+    +------------+--------+---------------------------------------------+
+    | python     | python | Cannot leave empty lines in defs            |
+    | javascript | node   | ignoreUndefined by default                  |
+    | coffee     | coffee | Blank lines show undefined                  |
+    | haskell    | ghci   | Language pragmas don't work                 |
+    | purescript | psci   | End multi-line continuations with :endpaste |
+    | ruby       | irb    |                                             |
+    | ocaml      | ocaml  | Must end every statement with ;;            |
+    | clojure    | planck |                                             |
+    | php        | psysh  |                                             |
+    | lua        | lua    | Use a = or return to display val            |
+    | cpp        | cling  |                                             |
+    +------------+--------+---------------------------------------------+
 
 Note that Codi is not meant to be a replacement for actually running your
 program; it supports nothing more than what the underlying bin supports. This


### PR DESCRIPTION
PureScript/PSCi is very similar to Haskell/GHCi.  It is a bit weird though in that multi-line input is started with a ":paste" command and ended with Ctrl-d. (Yes, the same Ctrl-d that shuts down the interpreter) It took me a bit to figure out that it takes 4 keypresses in the vim buffer to send this through to the interpreter:

Ctrl-v Ctrl-v Ctrl-v Ctrl-d
(Which appears as ^V^D)

So I added a note about that in the documentation. If you think that's too rough for the average user to handle I have a rephrase function that let's you get by with just Ctrl-v Ctrl-d or an ":endpaste" command instead.