### PR TITLE
fix Python's IndentationError issue

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -88,9 +88,9 @@ endfunction
 " Python rephrasers
 function! s:rp_py(buf)
   let b = a:buf
-  " Insert # in the blank lines above Python's class methods definition to avoid
+  " Insert # in the blank lines above Python's indention line to avoid
   " `IndentationError`.
-  let b = substitute(b, '\(\s*\n\)\+\(\n\s\+def\)\@=', '\=substitute(submatch(0), "\s*\n", "\r#", "g")', 'g')
+  let b = substitute(b, '\(\s*\n\)\+\(\n\s\+\w\+\)\@=', '\=substitute(submatch(0), "\s*\n", "\r#", "g")', 'g')
   return b
 endfunction
 

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -81,6 +81,9 @@ function! s:rp_purs(buf)
   " Remove comments. In PSCi they produce an error
   " (Multi-line comments not supported here)
   let b = substitute(b, '\%(^\|[\n\r\x00]\)\s*--[^\n\r\x00]*', '', 'g')
+  " Insert # in the blank lines above Python's class methods definition to avoid
+  " `IndentationError`.
+  let b = substitute(b, '\(\s*\n\)\+\(\n\s\+def\)\@=', '\=substitute(submatch(0), "\s*\n", "\r#", "g")', 'g')
   " Extra newline to flush any remaining 'lastline' from preprocess
   return b . "\n"
 endfunction
@@ -89,6 +92,7 @@ let s:codi_default_interpreters = {
       \ 'python': {
           \ 'bin': ['env', 'PYTHONSTARTUP=', 'python'],
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
+          \ 'rephrase': function('s:rp_purs'),
           \ },
       \ 'javascript': {
           \ 'bin': ['node', '-e', 'require("repl").start({ignoreUndefined: true, useGlobal: true})'],

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -81,18 +81,24 @@ function! s:rp_purs(buf)
   " Remove comments. In PSCi they produce an error
   " (Multi-line comments not supported here)
   let b = substitute(b, '\%(^\|[\n\r\x00]\)\s*--[^\n\r\x00]*', '', 'g')
+  " Extra newline to flush any remaining 'lastline' from preprocess
+  return b . "\n"
+endfunction
+
+" Python rephrasers
+function! s:rp_py(buf)
+  let b = a:buf
   " Insert # in the blank lines above Python's class methods definition to avoid
   " `IndentationError`.
   let b = substitute(b, '\(\s*\n\)\+\(\n\s\+def\)\@=', '\=substitute(submatch(0), "\s*\n", "\r#", "g")', 'g')
-  " Extra newline to flush any remaining 'lastline' from preprocess
-  return b . "\n"
+  return b
 endfunction
 
 let s:codi_default_interpreters = {
       \ 'python': {
           \ 'bin': ['env', 'PYTHONSTARTUP=', 'python'],
           \ 'prompt': '^\(>>>\|\.\.\.\) ',
-          \ 'rephrase': function('s:rp_purs'),
+          \ 'rephrase': function('s:rp_py'),
           \ },
       \ 'javascript': {
           \ 'bin': ['node', '-e', 'require("repl").start({ignoreUndefined: true, useGlobal: true})'],

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -394,8 +394,6 @@ notes:
 python~
 bin: python
 maintainer: @metakirby5
-notes:
-  - Cannot leave empty lines in defs
 
 ruby~
 maintainer: @metakirby5
@@ -406,15 +404,7 @@ program; it supports nothing more than what the underlying bin supports.
 This is why Haskell language pragmas don't work, PureScript only works
 inside a project folder, and OCaml statements must end with ;;. Also, in
 most whitespace-sensitive languages, an empty line represents the end of a
-definition, so the below Python class will not work in Codi:
->
-             class Test(object):
-                 def __init__(self):
-                     pass
-
-                 def oops_theres_an_empty_line_above_this(self):
-                     return 1
-<
+definition. 
 
 OUTPUT SPECIFICATION                           *codi-interpreters-output-spec*
 


### PR DESCRIPTION
Insert # in the blank lines above Python's class methods definition to avoid `IndentationError`