### PR TITLE
Fixing issue where signcolumn breaks codi buffer ui

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -144,7 +144,7 @@ augroup CODI
         \ nomodifiable nomodified
         \ nonu nornu nolist nomodeline nowrap
         \ statusline=\  nocursorline nocursorcolumn colorcolumn=
-        \ foldcolumn=0 nofoldenable winfixwidth
+        \ foldcolumn=0 nofoldenable winfixwidth signcolumn=no
         \ scrollbind
         \ | noremap <buffer> <silent> q <esc>:q<cr>
         \ | silent! setlocal cursorbind


### PR DESCRIPTION
I have `set signcolumn=yes` in my nvim config, which makes it so the sign column is always displayed. I don't really want that in the codi buffer, but more importantly it actually breaks the right aligned UI. When it is enabled the output in the codi buffer is off 'screen' because the textwidth is being set using the window width, which isn't necessarily the same as amount of screen real estate that the buffer content is afforded. 

To fix the problem of the text being shifted off screen I simply added the `signcolumn=no` to the filetype set up