### PR TITLE
Improving Haskell compatability

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -93,7 +93,8 @@ endfunction
 function! s:rp_hs(buf)
     let printer = 'let codiPrettyPrint = putStrLn . take 50 . show'
     let setprint = ':set -interactive-print codiPrettyPrint'
-    return "\n".printer."\n".setprint."\n".a:buf
+    let prompt1 = ':set prompt "Codi Prompt"'
+    return printer."\n".setprint."\n".prompt1."\n".a:buf
 endfunction
 
 " Php rephrasers
@@ -131,7 +132,7 @@ let s:codi_default_interpreters = {
           \ },
       \ 'haskell': {
           \ 'bin': ['ghci', '-ignore-dot-ghci'],
-          \ 'prompt': '^Prelude[^>|]*[>|] ',
+          \ 'prompt': '^Codi Prompt',
           \ 'rephrase': function('s:rp_hs'),
           \ },
       \ 'purescript': {

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -89,6 +89,13 @@ function! s:rp_purs(buf)
   return b . "\n"
 endfunction
 
+" Haskell rephrasers
+function! s:rp_hs(buf)
+    let printer = 'let codiPrettyPrint = putStrLn . take 50 . show'
+    let setprint = ':set -interactive-print codiPrettyPrint'
+    return "\n".printer."\n".setprint."\n".a:buf
+endfunction
+
 " Php rephrasers
 function! s:rp_php(buf)
   if a:buf[0:4] ==# '<?php'
@@ -123,8 +130,9 @@ let s:codi_default_interpreters = {
           \ 'prompt': '^coffee> ',
           \ },
       \ 'haskell': {
-          \ 'bin': 'ghci',
+          \ 'bin': ['ghci', '-ignore-dot-ghci'],
           \ 'prompt': '^Prelude[^>|]*[>|] ',
+          \ 'rephrase': function('s:rp_hs'),
           \ },
       \ 'purescript': {
           \ 'bin': ['pulp', 'psci'],


### PR DESCRIPTION
With this changes codi does't hang on input like `[1..]`, but there's a bug where the output is delayed by two lines. [https://asciinema.org/a/0N5Rf6KbY2wBnaiJgt6LAzUoy](https://asciinema.org/a/0N5Rf6KbY2wBnaiJgt6LAzUoy)

It's likely because the runtime doesn't like how the rephraser adds lines to the buffer. I'm not sure what to change.