### PR TITLE
percentage width support

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -198,7 +198,7 @@ function! s:pane_width()
   if match(width, '[.%]') > -1
     let raw          = str2float(substitute(width, '%', '', 'g'))
     let clamped      = raw > 100.0 ? 100.0 : (raw < 0.0 ? 0.0 : raw)
-    let min_width    = exists('&winwidth') ? &winwidth : 10
+    let min_width    = exists('&winwidth') ? &winwidth : 20
     let buffer_width = winwidth(bufwinnr('%'))
     let result       = ceil((buffer_width / 100.0) * clamped)
 

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -246,6 +246,11 @@ g:codi#autocmd
                                                                 *g:codi#width*
 g:codi#width
              The width of the Codi split.
+             It can be a |Number|, a |Float| or a percentage string such as
+             `'33%'` or `'33.33%'`. The width will be clamped between `0.0`
+             and `100.0`. This plugin respects the |minwidth| variable if it
+             is present, otherwise the minimum remaining width is 10 columns.
+             This rule counts for both panes.
 
              Default value is 40.
 


### PR DESCRIPTION
This is related to #94.

It allows `g:codi#width` to accept a `float` and a percent-like string (e.g. `'33.54%'`) aside from the default `number` type. This is handled in the following way:

- If it is a `number` (e.g. `30`, `40`) then return it
- If it is a `float` (e.g. `33.33`, `33`) or percent-like string (e.g. `'33.45%'`, `'33%'`)
    - then calculate the pane width based on the current pane
        - If the value is larger than `100.0%` then clamp it to `100.0%`
        - If the value is less than `0.0%` then clamp it to `0.0%`

Finally, if either pane width is less than Vims `:h minwidth` setting, the minimum width will be respected for that pane instead. Should this setting not exist a default of `20` columns will be used.
This only happens when a `float` or percent-like string is used. If an absolute width is used then it will be used as-is _without_ respecting Vims `minwidth`.

All this adds a little bit of bulk but it is worth the safety-nets that prevent a pane from going out of bounds or barely visible. I've tried to apply any convention I could use, tried to put the function in a decent place and used `s:get_opt('width')` as my input parameter, maybe other parts need to be changed or improved, let me know :)

I've tested it in Vim, NeoVim and Mvim and they all behave as expected (see #94 for version info).