### PR TITLE
Allow to complete user defined interpreters in `:Codi`

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -766,3 +766,14 @@ function! codi#run(bang, ...)
     return s:codi_spawn(filetype)
   endif
 endfunction
+
+" Command-line complete function 
+function! codi#complete(arg_lead, cmd_line, cursor_pos)
+    " Get all built-in interpreters and user-defined interpreters
+    let candidates = getcompletion('', 'filetype') + keys(g:codi#interpreters)
+    " Filter matches according to the prefix
+    if a:arg_lead != ""
+        let candidates = filter(candidates, 'v:val[:len(a:arg_lead) - 1] == a:arg_lead')
+    endif
+    return sort(candidates)
+endfunction

--- a/plugin/codi.vim
+++ b/plugin/codi.vim
@@ -73,5 +73,5 @@ if !exists('g:codi#log')
   let g:codi#log = ''
 endif
 
-command! -nargs=? -bang -bar -complete=filetype Codi call codi#run(<bang>0, <f-args>)
+command! -nargs=? -bang -bar -complete=customlist,codi#complete Codi call codi#run(<bang>0, <f-args>)
 command! -bar CodiUpdate call codi#update()


### PR DESCRIPTION
Hi @megalithic , thank you for this fantastic plugin, I like it very much!

I just add this config to my `vimrc` to specify the python interpreter version
```vim
let g:codi#interpreters = {
    \ 'python3': {
        \ 'bin': 'python3',
        \ 'prompt': '^\(>>>\|\.\.\.\) '
    \ },
    \ 'python2': {
        \ 'bin': 'python2',
        \ 'prompt': '^\(>>>\|\.\.\.\) '
    \ }
\ }
```
I typed `:Codi py` and pressed `<Tab>` to get my own interpreter name, only to find `python`. This PR add the command-line complete function for user-defined interpreters support.