### PR TITLE
Fix /usr/bin/script execution on non standard shell

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -411,6 +411,7 @@ function! s:codi_do_update()
             \ 'pty': 1,
             \ 'on_stdout': function('s:codi_nvim_callback'),
             \ 'on_stderr': function('s:codi_nvim_callback'),
+            \ 'env': {'SHELL': 'sh'}
             \}
       if opt_use_buffer_dir
         let job_options.cwd = buf_dir
@@ -418,8 +419,10 @@ function! s:codi_do_update()
       let job = jobstart(cmd, job_options)
       let id = job
     else
-      let job = job_start(s:scriptify(cmd),
-            \ { 'callback': 'codi#__vim_callback' })
+      let job = job_start(s:scriptify(cmd), { 
+            \ 'callback': 'codi#__vim_callback', 
+            \ 'env': {'SHELL': 'sh'}
+            \})
       let ch = job_getchannel(job)
       let id = s:ch_get_id(ch)
     endif


### PR DESCRIPTION
For my setup it fixes #62 

```
Linux 7 5.1.7-arch1-1-ARCH #1 SMP PREEMPT Tue Jun 4 15:47:45 UTC 2019 x86_64 GNU/Linux
vim 8.1
fish 3.02
```