### PR TITLE
Fix error with Python and Neovim

### DIFF
--- a/autoload/codi.vim
+++ b/autoload/codi.vim
@@ -309,7 +309,7 @@ function! s:preprocess(text, ...)
   let out = substitute(substitute(substitute(a:text,
         \ "\<cr>".'\|'."\<c-h>", '', 'g'),
         \ '\(^\|\n\)\(\^D\)\+', '\1', 'g'),
-        \ "\<esc>".'\[[0-9;]*\a', '', 'g')
+        \ "\<esc>".'\[?*[0-9;]*\a', '', 'g')
   if a:0 && has_key(a:1, 'preprocess')
     let out = a:1['preprocess'](out)
   endif
@@ -481,10 +481,9 @@ function! s:codi_nvim_callback(job_id, data, event)
     let s:nvim_async_lines[a:job_id] .= line
 
     " If we hit a newline, we're ready to handle the data
-    let parts = split(s:nvim_async_lines[a:job_id], "\<cr>", 1)
-    if len(parts) > 1
-      let input = parts[0]
-      let s:nvim_async_lines[a:job_id] = join(parts[1:], '')
+    if s:nvim_async_lines[a:job_id][-1:] == "\<cr>"
+      let input = s:nvim_async_lines[a:job_id]
+      let s:nvim_async_lines[a:job_id] = ''
       try
         call s:codi_handle_data(s:async_data[a:job_id], input)
       catch /E716/


### PR DESCRIPTION
This PR solves the problem described in issue #130 on my setup:
- Linux 5.10.4-arch2-1 SMP PREEMPT Fri, 01 Jan 2021 05:29:53 +0000 x86_64 GNU/Linux
- Neovim 0.4.4
- Python 3.9.1