### PR TITLE
add Haxe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ any language that provides a REPL (interactive interpreter)!
 
 Languages with built-in support:
 Python, JavaScript, CoffeeScript, Haskell, PureScript, Ruby, OCaml, R,
-Clojure/ClojureScript, PHP, Lua, C++, Julia, Elm, Elixir, TypeScript, Mathjs
+Clojure/ClojureScript, PHP, Lua, C++, Julia, Elm, Elixir, TypeScript, Mathjs, Haxe
 
 [Pull requests](https://github.com/metakirby5/codi.vim/pulls)
 for new language support welcome!
@@ -73,6 +73,7 @@ Default interpreter dependencies:
   - Elixir:       `iex`
   - TypeScript:   `tsun`
   - Mathjs:       `mathjs`
+  - Haxe:         `ihx` (installed with `haxelib install ihx`)
 
 ## Usage
 

--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -193,9 +193,14 @@ let s:codi_default_interpreters = {
          \ 'bin': ['iex'],
          \ 'prompt': '^iex(\d\+). '
          \ },
-       \ 'mathjs': {
+      \ 'mathjs': {
          \ 'bin': ['mathjs'],
          \ 'prompt': '^\(>\|\.\.\.\+\) ',
+         \ },
+      \ 'haxe': {
+         \ 'bin': ['haxelib', 'run', 'ihx', '-codi'],
+         \ 'prompt': '>> ',
+         \ 'quitcmd': 'exit',
          \ },
       \ }
 function! codi#load#interpreters()

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -473,6 +473,12 @@ bin: mathjs
 notes:
   - Evaluation may not work until a newline is entered
 
+haxe~
+bin: ihx 
+maintainer: @grepsuzette
+notes:
+  - `ihx` is an haxe interpreter and should be installed with `haxelib install ihx`
+
 Note that Codi is not meant to be a replacement for actually running your
 program; it supports nothing more than what the underlying bin supports.
 This is why Haskell language pragmas don't work, PureScript only works

--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -477,7 +477,7 @@ haxe~
 bin: ihx 
 maintainer: @grepsuzette
 notes:
-  - `ihx` is an haxe interpreter and should be installed with `haxelib install ihx`
+  - `ihx` is a Haxe interpreter and should be installed with `haxelib install ihx`
 
 Note that Codi is not meant to be a replacement for actually running your
 program; it supports nothing more than what the underlying bin supports.


### PR DESCRIPTION
This adds support for the [Haxe](https://haxe.org) language,
thanks to the [ihx](https://lib.haxe.org/p/ihx/) interpreter.

(It has some display glitches here and there sometimes when typing,
but I have been using it for years.)