### PR TITLE
Add note in Readme about Python 3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ need `ghci`.
 
 Default interpreter dependencies:
 
-  - Python:       `python`
+  - Python:       `python` (Note: Python 3 requires config - see `:h codi-configuration`)
   - JavaScript:   `node`
   - CoffeeScript: `coffee`
   - Haskell:      `ghci` (be really careful with lazy evaluation!)


### PR DESCRIPTION
I don't have Python 2 installed on my system, so Codi wasn't working for Python. It took me a while to figure out that Codi wasn't using Python 3. I figure there should be a note in the readme. (Maybe you would want to update the vim docs later, too...)

The note I added isn't really enough detail (I spent all of five minutes on it), but hopefully it's enough information to point users in the right direction.