### PR TITLE
Add codi#virtual_text_pos option

### DIFF
--- a/doc/codi.txt
+++ b/doc/codi.txt
@@ -339,6 +339,13 @@ g:codi#virtual_text_prefix
 
              Default value is "❯ "
 
+                                                      *g:codi#virtual_text_pos
+g:codi#virtual_text_pos
+             Position of the virtual text. Supported values: "eof",
+             "right_align", or a number for a specific column (ex: 90).
+
+             Default value is "eof".
+
                                                               *CodiVirtualText*
 CodiVirtualText
              Codi uses CodiVirtualText the custom highlight group to syntax


### PR DESCRIPTION
This PR adds an option `codi#virtual_text_pos` option that allow one to specify the position of the virtual text.
The default option is still `eof` but one can select `right_align` to have the text at the end of the window or a number can be specified to have the text align nicely at the specified column,