### PR TITLE
Fix codi not working in Ruby

### DIFF
--- a/autoload/codi/load.vim
+++ b/autoload/codi/load.vim
@@ -147,7 +147,7 @@ let s:codi_default_interpreters = {
           \ 'quitcmd': ':q',
           \ },
       \ 'ruby': {
-          \ 'bin': ['irb', '-f'],
+          \ 'bin': ['irb', '-f', '--nomultiline'],
           \ 'prompt': '^irb(\w\+):\d\+:\d\+. ',
           \ 'preprocess': function('s:pp_remove_fat_arrow'),
           \ },


### PR DESCRIPTION
I had the same issue as https://github.com/metakirby5/codi.vim/issues/133
This change fixed it

Thanks for the awesome plugin btw ❤️ 